### PR TITLE
fixed parse bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ fs.writeFileSync('./app.js', js, 'utf-8');
 function parse(content) {
   let i = 0;
   const ast = {};
-  ast.html = parseFragments(() => i < content.length);
+  ast.html = parseFragments(() => i < content.length - 1);
 
   return ast;
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ fs.writeFileSync('./app.js', js, 'utf-8');
 function parse(content) {
   let i = 0;
   const ast = {};
-  ast.html = parseFragments(() => i < content.length - 1);
+  ast.html = parseFragments(() => i < content.length);
 
   return ast;
 
@@ -120,7 +120,7 @@ function parse(content) {
   }
   function readWhileMatching(regex) {
     let startIndex = i;
-    while (regex.test(content[i])) {
+    while (i < content.length && regex.test(content[i])) {
       i++;
     }
     return content.slice(startIndex, i);


### PR DESCRIPTION
If the component file has `\n` at its last line, the while loop runs endlessly.
It happens because the current `parseFragments()` running while `i < content.length`, but since it's reading it's index `content[content.length]` will always be `undefined`. and if the last character is `\n` so it ends up in the `parseText()` with `readWhileMatching(/[^<{]/)` and `/[^<{]/.test(undefined)` returns `true` which makes the loop run endlessly.

so to use `parseFragments(() => i < content.length - 1);` makes more sense because `content[content.length - 1]` is the last character of the string

I found this because I use prettier, and when you format the file it's adding `\n` at the end.